### PR TITLE
Updated sensor friendly name

### DIFF
--- a/Citroen-ec4.md
+++ b/Citroen-ec4.md
@@ -154,7 +154,7 @@ Edit the file **/config/sensor.yaml** and add the following code, by replacing t
 - platform: template
   sensors:
     ec4_stop_hour:
-      friendly_name: "Charging postponed until"
+       friendly_name: "Next charging stop hour"
       value_template: "{{ state_attr('sensor.citroen_ec4_charge_control', '_next_stop_hour') }}"
       icon_template: mdi:clock-time-four-outline
     ec4_threshold:


### PR DESCRIPTION
ec4_stop_hour returns the next timestamp at which charging will be stopped (in order to achieve "set a stop hour to charge your vehicle only on off-peak hours" on PSA Car Controller" as on the PSA Car Controller docs).

Charging postpone or setting the Start time must be changed using http://127.0.0.1:5000/charge_hour?vin=YOURVIN&hour=22&minute=30 and the data configured there is accessible from the "car state" structure. I'm building sensors to set and return the data on those structures and will get back here once these are tested